### PR TITLE
Add Typekit.load

### DIFF
--- a/app/helpers/typekit/view_helper.rb
+++ b/app/helpers/typekit/view_helper.rb
@@ -3,6 +3,7 @@ module Typekit
     def typekit(kit_id)
       return if kit_id == '- YOUR KIT ID HERE -'
       content_tag :script, nil, src: "//use.typekit.com/#{kit_id}.js", async: true
+      content_tag :script, "try{Typekit.load({ async: true });}catch(e){}"
     end
   end
 end


### PR DESCRIPTION
TypeKit introduced the `async` attribute on `Typekit.load`, which should now load the font files declared in TypeKit's CSS `@font-face` asynchronously.

Source: 
http://blog.typekit.com/2015/08/04/new-embed-code-for-asynchronous-font-loading/
http://help.typekit.com/customer/portal/articles/649336-embed-code
